### PR TITLE
Manual local_host_name parameter for supvisors_list

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -47,13 +47,17 @@ behavior may happen. The present section details where it is applicable.
 
     The exhaustive form of an element matches ``<identifier>host_name:http_port:internal_port``, where:
 
-        * ``identifier`` is the optional but **unique** |Supervisor| identifier (it can be set in the |Supervisor|
+        * ``identifier`` (optional) is the **unique** |Supervisor| identifier (it can be set in the |Supervisor|
           configuration or in the command line when starting the ``supervisord`` program) ;
-        * ``host_name`` is the name of the node where the |Supvisors| instance is running ;
-        * ``http_port`` is the port of the internet socket used to communicate with the |Supervisor| instance
+        * ``host_name`` (required) is the name of the node where the |Supvisors| instance is running ;
+        * ``http_port`` (optional) is the port of the internet socket used to communicate with the |Supervisor| instance
           (obviously unique per node) ;
-        * ``internal_port`` is the port of the TCP socket used by the |Supvisors| instance to publish internal events
+        * ``internal_port`` (optional) is the port of the TCP socket used by the |Supvisors| instance to publish internal events
           (also unique per node).
+        * ``local_host_name`` (optional) is a parameter to manually specify the host machine's host name. Without this
+          option, the local_host_name is searched for in the supvisors_list. Manually specifying the local host name
+          can be necessary when the host machine is a cloud server that resolves its local host name differently than
+          it resolves the host name for it's public IP address. **Must** be one of the hosts listed in ``supvisors_list``.
 
     *Default*:  the local host name.
 

--- a/supvisors/options.py
+++ b/supvisors/options.py
@@ -79,7 +79,8 @@ class SupvisorsOptions:
         - stats_histo: depth of statistics history ;
         - stats_irix_mode: choice of CPU value display between IRIX and Solaris ;
         - tail_limit: the number of bytes used to display the log tail of the file in the Web UI (refresh mode) ;
-        - tailf_limit: the number of bytes used to display the log tail of the file in the Web UI (tail -f mode).
+        - tailf_limit: the number of bytes used to display the log tail of the file in the Web UI (tail -f mode). ;
+        - local_host_name: manually specifies the name of the host machine.
     """
 
     SYNCHRO_TIMEOUT_MIN = 15
@@ -147,6 +148,8 @@ class SupvisorsOptions:
         # configure log tail limits
         self.tail_limit = self._get_value(config, 'tail_limit', 1024, byte_size)
         self.tailf_limit = self._get_value(config, 'tailf_limit', 1024, byte_size)
+        # get local host mismatch option
+        self.local_host_name = self._get_value(config, 'local_host_name', None)
         # check synchro options consistence
         self.check_synchro_options()
 


### PR DESCRIPTION
This change adds a new option parameter for configuring ``[rpcinterface:supvisors]``, ``local_host_name``, which when specified is used as the host name for locating the local supervisor instance, rather than automatically identifying the local host from the provided s

This is useful when working on a cloud server where the host machine's host name is not the same as the host name it resolve's for it's public IP address.

Tested and confirmed to be working.

Test procedure I used:
AWS ec2 instance (Ubuntu 20.04)

```
; supervisord config
; ...
[rpcinterface:supvisors]
supervisors_list = my.server's.public-ip.address
```
^^^ Throws a value error

```
; supervisord config
; ...
[rpcinterface:supvisors]
supervisors_list = my.server's.public-ip.address
local_host_name = my.server's.public-ip.address
```
^^^ Runs successfully